### PR TITLE
Publically exposed to allow further customization

### DIFF
--- a/FZCarousel/FZCarouselView.h
+++ b/FZCarousel/FZCarouselView.h
@@ -22,8 +22,8 @@
 
 @interface FZCarouselView : UIView
 
-@property (strong, nonatomic) FZDefaultCarouselCollectionViewDelegate *carouselCollectionViewDelegate;
-@property (nonatomic, strong) UICollectionView *collectionView;
+@property (readonly, nonatomic) FZDefaultCarouselCollectionViewDelegate *carouselCollectionViewDelegate;
+@property (readonly, nonatomic) UICollectionView *collectionView;
 
 
 @property (nonatomic, strong) NSArray<UIImage *> *imageArray;

--- a/FZCarousel/FZCarouselView.h
+++ b/FZCarousel/FZCarouselView.h
@@ -8,6 +8,12 @@
 
 #import <UIKit/UIKit.h>
 
+#import "FZCarouselCollectionViewDelegate.h"
+
+
+@interface FZDefaultCarouselCollectionViewDelegate : FZCarouselCollectionViewDelegate
+@end
+
 /**
  * @description FZCarouselView is view with default implementation of FZCarouselCollectionViewDelegate that takes an array of images for an infinitely scrolling carousel.
  *
@@ -15,6 +21,10 @@
  */
 
 @interface FZCarouselView : UIView
+
+@property (strong, nonatomic) FZDefaultCarouselCollectionViewDelegate *carouselCollectionViewDelegate;
+@property (nonatomic, strong) UICollectionView *collectionView;
+
 
 @property (nonatomic, strong) NSArray<UIImage *> *imageArray;
 @property (nonatomic) BOOL gestureRecognitionShouldEndCarousel;

--- a/FZCarousel/FZCarouselView.m
+++ b/FZCarousel/FZCarouselView.m
@@ -38,7 +38,7 @@
 	
 	UICollectionViewFlowLayout *flowLayout = [UICollectionViewFlowLayout new];
 	[flowLayout setScrollDirection:UICollectionViewScrollDirectionHorizontal];
-	self.collectionView = [[UICollectionView alloc] initWithFrame:self.bounds collectionViewLayout:flowLayout];
+	_collectionView = [[UICollectionView alloc] initWithFrame:self.bounds collectionViewLayout:flowLayout];
 	[self.collectionView setTranslatesAutoresizingMaskIntoConstraints:NO];
 	[self.collectionView setShowsHorizontalScrollIndicator:NO];
 	[self addSubview:self.collectionView];
@@ -48,7 +48,7 @@
 	[self addConstraints:topAndBottom];
 	[self addConstraints:leftAndRight];
 	
-	self.carouselCollectionViewDelegate = [FZDefaultCarouselCollectionViewDelegate carouselCollectionViewDelegateForCollectionView:self.collectionView dataArray:self.imageArray crankInterval:self.crankInterval];
+	_carouselCollectionViewDelegate = [FZDefaultCarouselCollectionViewDelegate carouselCollectionViewDelegateForCollectionView:self.collectionView dataArray:self.imageArray crankInterval:self.crankInterval];
 	self.carouselCollectionViewDelegate.lazyCrankInterval = self.crankInterval;
 }
 

--- a/FZCarousel/FZCarouselView.m
+++ b/FZCarousel/FZCarouselView.m
@@ -7,25 +7,11 @@
 //
 
 #import "FZCarouselView.h"
-#import "FZCarouselCollectionViewDelegate.h"
-
-
-@interface FZDefaultCarouselCollectionViewDelegate : FZCarouselCollectionViewDelegate
-@end
 
 
 @interface FZDefaultCarouselCollectionViewCell : UICollectionViewCell
 @property (nonatomic, strong) UIImageView *imageView;
 @end
-
-
-@interface FZCarouselView()
-
-@property (strong, nonatomic) FZDefaultCarouselCollectionViewDelegate *carouselCollectionViewDelegate;
-@property (nonatomic, strong) UICollectionView *collectionView;
-
-@end
-
 
 @implementation FZCarouselView
 


### PR DESCRIPTION
With the default implementation of FZCarouselView make the default delegate and collection view publicly exposed to allow further customization. 

Hi Sheng! 

Obviously I could just point to ShakeShack to my repository, or send pull request directly to Fuzz, but what's the fun in that? Hope all is well, learning all about MVVM at timehop. 
